### PR TITLE
Let's wipe out the CRITICAL WORKER TIMEOUT errors

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -5,6 +5,6 @@ export PATH=$PATH:~/.local/bin
 # python manage.py makemigrations --noinput
 # python manage.py migrate --noinput
 # python manage.py collectstatic --noinput
-gunicorn emerresponseAPI.wsgi:application -b :8000 -k 'gevent' --keep-alive 60
+gunicorn emerresponseAPI.wsgi:application -b :8000 -k 'gevent'
 # gunicorn emerresponseAPI.wsgi:application -b :8000
 # python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Removing the keepalive that correlates with the CRITICAL WORKER TIMEOUT errors that we have removed from all other projects.