### PR TITLE
Update pytest-django to support pytest 5.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -27,5 +27,5 @@ openapi-codec==1.3.2
 django-rest-swagger
 
 # Testing
-pytest-django==3.2.1
+pytest-django==3.5.1
 tblib==1.3.2


### PR DESCRIPTION
Pytest 5.0 just came out and causes test failures due to deprecations within `pytest-django`.